### PR TITLE
Lv 4: AOP를 활용한 API 로깅

### DIFF
--- a/src/main/java/org/example/expert/config/JwtFilter.java
+++ b/src/main/java/org/example/expert/config/JwtFilter.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.expert.domain.user.enums.UserRole;
+import org.springframework.web.util.ContentCachingRequestWrapper;
 
 import java.io.IOException;
 
@@ -28,16 +29,17 @@ public class JwtFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
+        ContentCachingRequestWrapper cachingRequest = new ContentCachingRequestWrapper(httpRequest);
         HttpServletResponse httpResponse = (HttpServletResponse) response;
 
         String url = httpRequest.getRequestURI();
 
         if (url.startsWith("/auth")) {
-            chain.doFilter(request, response);
+            chain.doFilter(cachingRequest, response);
             return;
         }
 
-        String bearerJwt = httpRequest.getHeader("Authorization");
+        String bearerJwt = cachingRequest.getHeader("Authorization");
 
         if (bearerJwt == null) {
             // 토큰이 없는 경우 400을 반환합니다.
@@ -57,9 +59,9 @@ public class JwtFilter implements Filter {
 
             UserRole userRole = UserRole.valueOf(claims.get("userRole", String.class));
 
-            httpRequest.setAttribute("userId", Long.parseLong(claims.getSubject()));
-            httpRequest.setAttribute("email", claims.get("email"));
-            httpRequest.setAttribute("userRole", claims.get("userRole"));
+            cachingRequest.setAttribute("userId", Long.parseLong(claims.getSubject()));
+            cachingRequest.setAttribute("email", claims.get("email"));
+            cachingRequest.setAttribute("userRole", claims.get("userRole"));
 
             if (url.startsWith("/admin")) {
                 // 관리자 권한이 없는 경우 403을 반환합니다.
@@ -67,11 +69,11 @@ public class JwtFilter implements Filter {
                     httpResponse.sendError(HttpServletResponse.SC_FORBIDDEN, "관리자 권한이 없습니다.");
                     return;
                 }
-                chain.doFilter(request, response);
+                chain.doFilter(cachingRequest, response);
                 return;
             }
 
-            chain.doFilter(request, response);
+            chain.doFilter(cachingRequest, response);
         } catch (SecurityException | MalformedJwtException e) {
             log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.", e);
             httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않는 JWT 서명입니다.");

--- a/src/main/java/org/example/expert/config/PropertyConfig.java
+++ b/src/main/java/org/example/expert/config/PropertyConfig.java
@@ -1,0 +1,12 @@
+package org.example.expert.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
+
+@Configuration
+@PropertySources({
+    @PropertySource("classpath:env.properties")
+})
+public class PropertyConfig {
+}

--- a/src/main/java/org/example/expert/domain/comment/controller/CommentAdminController.java
+++ b/src/main/java/org/example/expert/domain/comment/controller/CommentAdminController.java
@@ -2,6 +2,7 @@ package org.example.expert.domain.comment.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.expert.domain.comment.service.CommentAdminService;
+import org.example.expert.domain.common.annotation.LogTrace;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,6 +13,7 @@ public class CommentAdminController {
 
     private final CommentAdminService commentAdminService;
 
+    @LogTrace
     @DeleteMapping("/admin/comments/{commentId}")
     public void deleteComment(@PathVariable long commentId) {
         commentAdminService.deleteComment(commentId);

--- a/src/main/java/org/example/expert/domain/common/annotation/LogTrace.java
+++ b/src/main/java/org/example/expert/domain/common/annotation/LogTrace.java
@@ -1,0 +1,11 @@
+package org.example.expert.domain.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogTrace {
+}

--- a/src/main/java/org/example/expert/domain/common/aspect/LogTraceAspect.java
+++ b/src/main/java/org/example/expert/domain/common/aspect/LogTraceAspect.java
@@ -1,0 +1,115 @@
+package org.example.expert.domain.common.aspect;
+
+import io.jsonwebtoken.Claims;
+import io.micrometer.common.util.StringUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.example.expert.config.JwtUtil;
+import org.example.expert.domain.common.exception.InvalidRequestException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import java.io.UnsupportedEncodingException;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class LogTraceAspect {
+
+    private final JwtUtil jwtUtil;
+
+    @Pointcut("@annotation(org.example.expert.domain.common.annotation.LogTrace)")
+    public void loggerPointcut() {
+    }
+
+    @Around("loggerPointcut()")
+    public Object doLogTrace(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        final ContentCachingRequestWrapper cachingRequest = (ContentCachingRequestWrapper) request;
+
+        String traceId = UUID.randomUUID().toString().substring(0, 8);
+        String requestBody = getRequestBody(cachingRequest, request);
+        if (requestBody == null || StringUtils.isBlank(requestBody)) {
+            requestBody = "empty";
+        }
+        String method = cachingRequest.getMethod();
+        LocalDateTime requestTime = LocalDateTime.now();
+
+        // userId를 가져오기 위해 헤더에서 토큰을 가져온 뒤 Claims 추출
+        String accessToken = request.getHeader("Authorization");
+        String substringBearer = jwtUtil.substringToken(accessToken);
+        Claims claims = jwtUtil.extractClaims(substringBearer);
+
+        log.info(toRequestLog(traceId, method, claims.getSubject(), cachingRequest.getRequestURL(), requestTime, requestBody));
+
+        Object result = proceedingJoinPoint.proceed();  // proxy 객체가 target 객체의 메서드를 호출하고 나온 result
+        if (result == null || StringUtils.isBlank(result.toString())) {
+            result = "empty";
+        }
+
+        log.info(toResponseLog(traceId, method, cachingRequest.getRequestURL(), claims.getSubject(), requestTime, result));
+        return result;
+    }
+
+    private String getRequestBody(ContentCachingRequestWrapper cachingRequest, HttpServletRequest request) {
+        String requestBody = "";
+        try {
+            requestBody = new String(cachingRequest.getContentAsByteArray(), request.getCharacterEncoding());
+        } catch (UnsupportedEncodingException uee) {
+            throw new InvalidRequestException("Logging 과정에서 에러가 발생했습니다.");
+        }
+        return requestBody;
+    }
+
+    public String toRequestLog(
+        String traceId,
+        String method,
+        String subject,
+        StringBuffer requestUrl,
+        LocalDateTime requestTime,
+        String requestBody
+    ) {
+        return String.format(
+            "%n========== HTTP REQUEST LOG ==========%n" +
+                "Trace ID        : %s%n" +
+                "HTTP Method     : %s%n" +
+                "Request URI     : %s%n" +
+                "Request User ID : %s%n" +
+                "Request Time    : %s%n" +
+                "Request Body    : %s%n" +
+                "======================================",
+            traceId, method, requestUrl, subject, requestTime, requestBody
+        );
+    }
+
+    public String toResponseLog(
+        String traceId,
+        String method,
+        StringBuffer requestUrl,
+        String subject,
+        LocalDateTime requestTime,
+        Object result
+    ) {
+        return String.format(
+            "%n========== HTTP REQUEST LOG ==========%n" +
+                "Trace ID        : %s%n" +
+                "HTTP Method     : %s%n" +
+                "Request URI     : %s%n" +
+                "Request User ID : %s%n" +
+                "Request Time    : %s%n" +
+                "Response Body   : %s%n" +
+                "======================================",
+            traceId, method, requestUrl, subject, requestTime, result
+        );
+    }
+}

--- a/src/main/java/org/example/expert/domain/user/controller/UserAdminController.java
+++ b/src/main/java/org/example/expert/domain/user/controller/UserAdminController.java
@@ -1,6 +1,7 @@
 package org.example.expert.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.expert.domain.common.annotation.LogTrace;
 import org.example.expert.domain.user.dto.request.UserRoleChangeRequest;
 import org.example.expert.domain.user.service.UserAdminService;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -14,6 +15,7 @@ public class UserAdminController {
 
     private final UserAdminService userAdminService;
 
+    @LogTrace
     @PatchMapping("/admin/users/{userId}")
     public void changeUserRole(@PathVariable long userId, @RequestBody UserRoleChangeRequest userRoleChangeRequest) {
         userAdminService.changeUserRole(userId, userRoleChangeRequest);

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: none
+    open-in-view: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+spring:
+  config:
+    import:
+      - classpath:application-datasource.yml
+
+jwt:
+  secret:
+    key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
- 설정 파일 추가
- 커스텀 어노테이션을 사용해서 포인트컷 설정
- proceed 전/후로 로깅 처리
- UUID로 traceId 설정
- JwtFilter에서 요청 본문을 캐싱 처리해서 이후 여러 컴포넌트에서 요청 본문을 여러 번 읽을 수 있도록 함
- RequestContextHolder를 이용하여 현재 스레드에 바인딩된 HttpServletRequest를 가져옴